### PR TITLE
rakeタスクでリマインダーをDiscordに飛ばせるようにした

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,8 @@ gem "puma", "~> 5.0"
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 
+gem 'discordrb'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,9 +73,24 @@ GEM
       irb (>= 1.3.6)
       reline (>= 0.2.7)
     digest (3.1.0)
+    discordrb (3.4.0)
+      discordrb-webhooks (~> 3.3.0)
+      ffi (>= 1.9.24)
+      opus-ruby
+      rest-client (>= 2.0.0)
+      websocket-client-simple (>= 0.3.0)
+    discordrb-webhooks (3.3.0)
+      rest-client (>= 2.1.0.rc1)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     erubi (1.10.0)
+    event_emitter (0.2.6)
+    ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.4)
+      domain_name (~> 0.5)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     io-console (0.5.11)
@@ -89,6 +104,9 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2022.0105)
     mini_mime (1.1.2)
     mini_portile2 (2.7.1)
     minitest (5.15.0)
@@ -107,10 +125,13 @@ GEM
       digest
       net-protocol
       timeout
+    netrc (0.11.0)
     nio4r (2.5.8)
     nokogiri (1.13.1)
       mini_portile2 (~> 2.7.0)
       racc (~> 1.4)
+    opus-ruby (1.0.1)
+      ffi
     pg (1.3.2)
     puma (5.6.2)
       nio4r (~> 2.0)
@@ -147,6 +168,11 @@ GEM
     rake (13.0.6)
     reline (0.3.1)
       io-console (~> 0.5)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -159,6 +185,13 @@ GEM
     timeout (0.2.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8)
+    websocket (1.2.9)
+    websocket-client-simple (0.5.1)
+      event_emitter
+      websocket
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -169,6 +202,7 @@ PLATFORMS
 
 DEPENDENCIES
   debug
+  discordrb
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.2, >= 7.0.2.2)

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,7 +28,7 @@ module ReminderBot
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = 'Tokyo'
     # config.eager_load_paths << Rails.root.join("extras")
 
     # Don't generate system test files.

--- a/lib/tasks/remind.rake
+++ b/lib/tasks/remind.rake
@@ -1,0 +1,16 @@
+require 'discordrb/webhooks'
+
+namespace :reminder do
+  desc 'リマインド実行'
+  task call: :environment do
+    reminders = Reminder.where(remind_at: (5.minutes.ago)..(5.minutes.since))
+    WEBHOOK_URL = ENV['WEBHOOK_URL']
+    client = Discordrb::Webhooks::Client.new(url: WEBHOOK_URL)
+
+    reminders.each do |reminder|
+      client.execute do |builder|
+        builder.content = "#{reminder.message}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## できるようになったこと

画面から登録したリマインダーをrakeタスクでDiscordチャンネルに飛ばせる

## やったこと

- [discordrb](https://github.com/shardlab/discordrb)をインストール
- システムのタイムゾーンを日本(Tokyo)に設定
- remindersテーブルのレコードからDiscordのチャンネルにメッセージを飛ばすrake taskを書いた

## 別PRで対応

- webhookのurlの管理
    - オープンソースなので見えないように管理する
    - #5 
- リマインドメッセージのメンション対応
    - ユーザー名で飛ばしてもメンションにならないので`\@username`で取得したIDを設定する必要がある
    - #6 