### PR TITLE
rakeタスクの処理をクラスに切り出した

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -1,0 +1,1 @@
+WEBHOOK_URL=hogefuga

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'discordrb'
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
+  gem 'dotenv-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,10 @@ GEM
       rest-client (>= 2.1.0.rc1)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.10.0)
     event_emitter (0.2.6)
     ffi (1.15.5)
@@ -203,6 +207,7 @@ PLATFORMS
 DEPENDENCIES
   debug
   discordrb
+  dotenv-rails
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.2, >= 7.0.2.2)

--- a/app/models/discord_messenger.rb
+++ b/app/models/discord_messenger.rb
@@ -1,0 +1,10 @@
+class DiscordMessenger
+  WEBHOOK_URL = ENV['WEBHOOK_URL']
+
+  def self.send(message)
+    client = Discordrb::Webhooks::Client.new(url: WEBHOOK_URL)
+    client.execute do |builder|
+      builder.content = "#{message}"
+    end
+  end
+end

--- a/app/models/interval_reminder.rb
+++ b/app/models/interval_reminder.rb
@@ -1,4 +1,6 @@
 class IntervalReminder < Reminder
   def remind
+    DiscordMessenger.send(message)
+    update(remind_at: remind_at + interval_seconds)
   end
 end

--- a/app/models/interval_reminder.rb
+++ b/app/models/interval_reminder.rb
@@ -1,2 +1,4 @@
 class IntervalReminder < Reminder
+  def remind
+  end
 end

--- a/app/models/reminder.rb
+++ b/app/models/reminder.rb
@@ -1,2 +1,6 @@
 class Reminder < ApplicationRecord
+  def self.remind
+    reminders = Reminder.where(remind_at: (5.minutes.ago)..(5.minutes.since))
+    reminders.each(&:remind)
+  end
 end

--- a/app/models/spot_reminder.rb
+++ b/app/models/spot_reminder.rb
@@ -1,4 +1,5 @@
 class SpotReminder < Reminder
   def remind
+    DiscordMessenger.send(message)
   end
 end

--- a/app/models/spot_reminder.rb
+++ b/app/models/spot_reminder.rb
@@ -1,2 +1,4 @@
 class SpotReminder < Reminder
+  def remind
+  end
 end

--- a/lib/tasks/remind.rake
+++ b/lib/tasks/remind.rake
@@ -3,14 +3,6 @@ require 'discordrb/webhooks'
 namespace :reminder do
   desc 'リマインド実行'
   task call: :environment do
-    reminders = Reminder.where(remind_at: (5.minutes.ago)..(5.minutes.since))
-    WEBHOOK_URL = ENV['WEBHOOK_URL']
-    client = Discordrb::Webhooks::Client.new(url: WEBHOOK_URL)
-
-    reminders.each do |reminder|
-      client.execute do |builder|
-        builder.content = "#{reminder.message}"
-      end
-    end
+    Reminder.remind
   end
 end


### PR DESCRIPTION
## 概要

SpotとInteval の Reminder を discord に投げられるようにした。

## 動作確認方法

画面から reminder を登録後 `bin/rails reminder:call` を実行してください
