### PR TITLE
Railsのアップグレードの際にbundleコマンド実行が漏れていたのでbundleコマンドを実行した

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,7 +205,7 @@ DEPENDENCIES
   discordrb
   pg (~> 1.1)
   puma (~> 5.0)
-  rails (~> 7.0.2, >= 7.0.2.2)
+  rails (= 7.0.2.3)
   sprockets-rails
   tzinfo-data
 


### PR DESCRIPTION
## なぜ必要か

#10 の対応の際、bundleコマンドの実行が漏れており、mainブランチでbundleコマンドを実行するとGemfile.lockの差分が出てしまっていたため、PRにしました