### PR TITLE
画面からIntervalSecondsを1日単位で登録できようにした

### DIFF
--- a/app/controllers/reminders_controller.rb
+++ b/app/controllers/reminders_controller.rb
@@ -53,6 +53,6 @@ class RemindersController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def reminder_params
-      params.require(:reminder).permit(:remind_at, :message, :interval_seconds, :type)
+      params.require(:reminder).permit(:remind_at, :message, :interval_days, :type)
     end
 end

--- a/app/models/reminder.rb
+++ b/app/models/reminder.rb
@@ -13,6 +13,6 @@ class Reminder < ApplicationRecord
   def interval_days
     return if interval_seconds.nil?
 
-    self.interval_seconds / (60 * 60 * 24)
+    self.interval_seconds / 1.day
   end
 end

--- a/app/models/reminder.rb
+++ b/app/models/reminder.rb
@@ -5,10 +5,14 @@ class Reminder < ApplicationRecord
   end
 
   def interval_days=(days)
+    return if days.blank?
+
     self.interval_seconds = days.to_i.days
   end
 
   def interval_days
+    return if interval_seconds.nil?
+
     self.interval_seconds / (60 * 60 * 24)
   end
 end

--- a/app/models/reminder.rb
+++ b/app/models/reminder.rb
@@ -3,4 +3,12 @@ class Reminder < ApplicationRecord
     reminders = Reminder.where(remind_at: (5.minutes.ago)..(5.minutes.since))
     reminders.each(&:remind)
   end
+
+  def interval_days=(days)
+    self.interval_seconds = days.to_i.days
+  end
+
+  def interval_days
+    self.interval_seconds / (60 * 60 * 24)
+  end
 end

--- a/app/views/reminders/_form.html.erb
+++ b/app/views/reminders/_form.html.erb
@@ -22,8 +22,8 @@
   </div>
 
   <div>
-    <%= form.label :interval_seconds, style: "display: block" %>
-    <%= form.number_field :interval_seconds %>
+    <%= form.label :interval_days, style: "display: block" %>
+    <%= form.number_field :interval_days %>
   </div>
 
   <div>


### PR DESCRIPTION
## 概要
close: https://github.com/shibaaaa/reminder_bot/issues/14

画面から IntervalSeconds を1日単位で登録できるようにした。

これまでは、ユーザー入力は秒だったが、これにより `7` と入力すると変換処理が走って `604800` と DB に登録されるようになった。

## 動作確認方法

1. http://localhost:3000/reminders/new で interval_days を含む IntervalReminder を登録
2. DB に interval_days が変換された秒数が interval_seconds に INSERT されることを確認