### PR TITLE
リマインダー作成時にwebhook URLとチャンネル名を登録できるようにした

### DIFF
--- a/app/controllers/reminders_controller.rb
+++ b/app/controllers/reminders_controller.rb
@@ -54,6 +54,6 @@ class RemindersController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def reminder_params
-      params.require(:reminder).permit(:remind_at, :message, :interval_days, :type)
+      params.require(:reminder).permit(:remind_at, :message, :interval_days, :type, :webhook_url, :channel_name)
     end
 end

--- a/app/models/reminder.rb
+++ b/app/models/reminder.rb
@@ -1,4 +1,10 @@
 class Reminder < ApplicationRecord
+  validates :channel_name, presence: true
+  validates :message,      presence: true
+  validates :remind_at,    presence: true
+  validates :type,         presence: true
+  validates :webhook_url,  presence: true
+
   def self.remind
     reminders = Reminder.where(remind_at: (5.minutes.ago)..(5.minutes.since))
     reminders.each(&:remind)

--- a/app/views/reminders/_form.html.erb
+++ b/app/views/reminders/_form.html.erb
@@ -21,6 +21,18 @@
     <%= form.text_area :message %>
   </div>
 
+  <% if @reminder.new_record? %>
+    <div>
+      <%= form.label :webhook_url, style: "display: block" %>
+      <%= form.text_field :webhook_url %>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :channel_name, style: "display: block" %>
+    <%= form.text_field :channel_name %>
+  </div>
+
   <div>
     <%= form.label :interval_days, style: "display: block" %>
     <%= form.number_field :interval_days %>

--- a/app/views/reminders/_form.html.erb
+++ b/app/views/reminders/_form.html.erb
@@ -13,24 +13,24 @@
 
   <div>
     <%= form.label :remind_at, style: "display: block" %>
-    <%= form.datetime_field :remind_at, step: 600 %>
+    <%= form.datetime_field :remind_at, step: 600, required: true %>
   </div>
 
   <div>
     <%= form.label :message, style: "display: block" %>
-    <%= form.text_area :message %>
+    <%= form.text_area :message, required: true %>
   </div>
 
   <% if @reminder.new_record? %>
     <div>
       <%= form.label :webhook_url, style: "display: block" %>
-      <%= form.text_field :webhook_url %>
+      <%= form.text_field :webhook_url, required: true %>
     </div>
   <% end %>
 
   <div>
     <%= form.label :channel_name, style: "display: block" %>
-    <%= form.text_field :channel_name %>
+    <%= form.text_field :channel_name, required: true %>
   </div>
 
   <div>
@@ -41,7 +41,7 @@
   <div>
     <%= form.label :type, style: "display: block" %>
 
-    <%= form.collection_radio_buttons :type, %w[SpotReminder IntervalReminder], :to_s, :to_s %>
+    <%= form.collection_radio_buttons :type, %w[SpotReminder IntervalReminder], :to_s, :to_s, {}, required: true %>
   </div>
 
   <div>

--- a/db/migrate/20220418113046_add_webhook_url_and_channel_name_to_reminders.rb
+++ b/db/migrate/20220418113046_add_webhook_url_and_channel_name_to_reminders.rb
@@ -1,0 +1,8 @@
+class AddWebhookUrlAndChannelNameToReminders < ActiveRecord::Migration[7.0]
+  def change
+    change_table(:reminders) do |t|
+      t.string :webhook_url, null: false
+      t.string :channel_name, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_02_21_112004) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_18_113046) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_21_112004) do
     t.string "type", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "webhook_url", null: false
+    t.string "channel_name", null: false
     t.index ["remind_at"], name: "index_reminders_on_remind_at"
   end
 


### PR DESCRIPTION
close: #31 

- webhook_url と channel_name のカラムを追加
-  webhook_url と channel_name を登録できるようにした
- リマンダー登録フォームに required 属性を付与