### PR TITLE
毎週金曜日にgemのアップデートがあればdependabotがPRを作成するようにした

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    target-branch: "main"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      timezone: "Asia/Tokyo"
+    versioning-strategy: "lockfile-only"
+    open-pull-requests-limit: 3


### PR DESCRIPTION
- 参考
    - [Configuration options for the dependabot\.yml file \- GitHub Docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)
    - [【Ruby on Rails】Gemの依存関係を監視させる　～ GitHub Dependabot ～ \- Qiita](https://qiita.com/otinu/items/954cba6ea10ace178fef)
    - [Dependabot を使ってGitHubのGemfileのアップデートのPRを作る](https://zenn.dev/junara/articles/347f2d709f71d3)