### PR TITLE
botが作成したPRの場合はアサインのjobを動かさないようにした

### DIFF
--- a/.github/workflows/pr-assign.yml
+++ b/.github/workflows/pr-assign.yml
@@ -8,7 +8,7 @@ jobs:
   assign:
     runs-on: ubuntu-20.04
     timeout-minutes: 1
-
+    if: ${{ github.actor != 'dependabot[bot]' && toJSON(github.event.pull_request.assignees) == '[]'}}
     steps:
       - run: cat $GITHUB_EVENT_PATH
       - run: gh pr edit $NUMBER --add-assignee $ASSIGNEE
@@ -17,4 +17,3 @@ jobs:
           GH_REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.pull_request.number }}
           ASSIGNEE: ${{ github.event.pull_request.user.login }}
-        if: ${{ toJSON(github.event.pull_request.assignees) == '[]' }}


### PR DESCRIPTION
dependabotが作成するPRに対しては該当のActionsを動かす必要がないため