### PR TITLE
00分台に heroku scheduler がタスクを実行できない問題に対応

### DIFF
--- a/lib/tasks/remind.rake
+++ b/lib/tasks/remind.rake
@@ -4,5 +4,14 @@ namespace :reminder do
   desc 'リマインド実行'
   task call: :environment do
     Reminder.remind
+
+    # NOTE: heroku scheduler の実行時間を10分毎に設定している。
+    #  しかし、00分台にタスクが実行されないという問題があった。つまり、20:50 に実行したら、次回実行時間は 21:10 になる。
+    #  00分台にタスクを実行させたいため、50分台に実行されたタスクだけはスリープすることで活かし続けている。
+    current_minutes = Time.current.min
+    if (50..55).cover?(current_minutes)
+      sleep (60 - current_minutes) * 60
+      Reminder.remind
+    end
   end
 end


### PR DESCRIPTION
close: https://github.com/shibaaaa/reminder_bot/issues/33

https://github.com/shibaaaa/reminder_bot/issues/33#issuecomment-1108509415 の案を採用して、上記の問題に対応した。

50分台に以下を実行すると、sleep されて、タスクが生き続けます。

```shell
bin/rails reminder:call
```