### PR TITLE
Reminder一覧・詳細画面でIntervalReminderのみInterval secondsを表示するようにした

### DIFF
--- a/app/views/reminders/_reminder.html.erb
+++ b/app/views/reminders/_reminder.html.erb
@@ -9,10 +9,12 @@
     <%= reminder.message %>
   </p>
 
-  <p>
-    <strong>Interval seconds:</strong>
-    <%= reminder.interval_seconds %>
-  </p>
+  <% if reminder.type == 'IntervalReminder' %>
+    <p>
+      <strong>Interval seconds:</strong>
+      <%= reminder.interval_seconds %>
+    </p>
+  <% end %>
 
   <p>
     <strong>Type:</strong>


### PR DESCRIPTION
close: #44 

## 一覧画面

<img width="364" alt="image" src="https://user-images.githubusercontent.com/56685224/172031975-8e3c0229-3520-4bdf-ab14-07b006fb203a.png">



## 詳細画面

### Spot Reminder

<img width="361" alt="image" src="https://user-images.githubusercontent.com/56685224/172031979-3f9c9840-f74b-4167-8027-0e41499dcd36.png">


### Interval Reminder

<img width="372" alt="image" src="https://user-images.githubusercontent.com/56685224/172031971-319a2a8a-83b8-4637-b95c-afd3453ed766.png">

